### PR TITLE
[CAX -769] pin github action dependencies to commit sha for workflow security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.1.0
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4
         with:
           node-version: '20'
       - name: Clean install of dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #v4
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4
         with:
           node-version: "20"
           registry-url: "https://npm.pkg.github.com/"


### PR DESCRIPTION
update GitHub Actions to use specific versions for checkout and setup-node